### PR TITLE
Correct sdp

### DIFF
--- a/lib/payload-combiner.js
+++ b/lib/payload-combiner.js
@@ -63,7 +63,7 @@ module.exports = function(opts, boundary) {
 </recording>`.replace(/\n/g, CRLF);
 
   const payload =
-    `${boundary}${CRLF}${ctSdp}${CRLF2}${sdp}${CRLF}${boundary}${CRLF}${ctXml}${CRLF2}${xmlData}${CRLF2}${boundary}${CRLF}`;
+    `${boundary}${CRLF}${ctSdp}${CRLF2}${sdp}${CRLF}${boundary}${CRLF}${ctXml}${CRLF2}${xmlData}${CRLF2}${boundary}--${CRLF}`;
 
   return payload;
 };

--- a/test/data/cisco-siprec-offer.txt
+++ b/test/data/cisco-siprec-offer.txt
@@ -67,7 +67,7 @@ Content-Type: application/rs-metadata+xml
 </participantstreamassoc>
 </recording>
 
---uniqueBoundary
+--uniqueBoundary--
 Content-Disposition: signal;handling=optional
 Content-Type: application/gtd
 


### PR DESCRIPTION
Hello
I see that the sdp lacks 2 hyphens to be compatible with rfc standard though everthing run well.
```
 The boundary delimiter line following the last body part is a
 distinguished delimiter that indicates that no further body parts
 will follow.  Such a delimiter line is identical to the previous
 delimiter lines, with the addition of two more hyphens after the
 boundary parameter value.

 --gc0pJq0M:08jU534c0p--
```
Reference: [rfc2046](https://datatracker.ietf.org/doc/html/rfc2046)